### PR TITLE
Fix broken "Edit this page on Github" links on website

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,7 +7,7 @@ site_url: https://examples.openshift.pub
 # Repository
 repo_name: openshift-examples/web
 repo_url: https://github.com/openshift-examples/web
-edit_uri: edit/master/
+edit_uri: edit/master/content/
 # Copyright
 copyright: <a href="/impressum/">Impressum</a>
 


### PR DESCRIPTION
Clicking the "Edit this page" link on the website leads to "404 Page not found errors" due to incorrect path.