### PR TITLE
Add strategy=docker

### DIFF
--- a/content/cluster-configuration/monitoring/alertmanager/telegram-receiver.md
+++ b/content/cluster-configuration/monitoring/alertmanager/telegram-receiver.md
@@ -16,7 +16,7 @@ Connected Prometheus alertmanager via [webhook receiver](https://prometheus.io/d
 ```bash
 oc new-project telegram
 # Build and deploy
-oc new-app --name=telegram \
+oc new-app --name=telegram --strategy=docker --context-dir=docker\
     https://github.com/openshift-examples/alertmanager-webhook-telegram.git
 ```
 


### PR DESCRIPTION
Without strategy=docker, the oc new-app creates the deployment target port 8080. While in the docker file the container is exposing port 9119