### PR TITLE
Fix tags of client page

### DIFF
--- a/content/client/index.md
+++ b/content/client/index.md
@@ -2,10 +2,7 @@
 title: OpenShift/Kubernetes Client
 linktitle: Client (oc/kubectl)
 description: All about OpenShift/Kubernetes clients
-tags:
-  - client
-  - kubectl
-  - oc
+tags: ["client", "kubectl", "oc"]
 ---
 # OpenShift/Kubernetes Client
 

--- a/content/client/index.md
+++ b/content/client/index.md
@@ -2,7 +2,10 @@
 title: OpenShift/Kubernetes Client
 linktitle: Client (oc/kubectl)
 description: All about OpenShift/Kubernetes clients
-tags: client, kubectl, oc
+tags:
+  - client
+  - kubectl
+  - oc
 ---
 # OpenShift/Kubernetes Client
 


### PR DESCRIPTION
At the moment, every character is interpreted as one tag.
See: https://examples.openshift.pub/client/