### PR TITLE
Add Gatekeeper — Automatic SCC Assignment page

### DIFF
--- a/.bob/skills/run-linter/SKILL.md
+++ b/.bob/skills/run-linter/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: run-linter
+description: Use when the user wants to run the linter, pre-commit checks, or markdownlint/yamllint on this project. Covers the requirement to stage/commit changes first.
+---
+
+# Run Linter / Pre-commit Checks
+
+This project uses `./run-local-pre-commit.sh` to execute markdownlint and yamllint via pre-commit.
+
+## Important constraint
+
+**All changes must be committed (or at least staged) before running the linter.**
+Pre-commit hooks in this project operate on committed/staged content.
+Uncommitted file changes will not be picked up correctly.
+
+## Steps
+
+1. Stage or commit all relevant changes:
+
+   ```shell
+   git add .
+   git commit -m "wip: changes before lint check"
+   ```
+
+   (Or use `git add .` alone if you want to keep them as staged rather than committed.)
+
+2. Run the linter:
+
+   ```shell
+   ./run-local-pre-commit.sh
+   ```
+
+3. If lint errors are reported, fix them, stage/commit the fixes, and re-run step 2 until clean.

--- a/content/README.md
+++ b/content/README.md
@@ -24,6 +24,7 @@ and benefit from the expertise shared in this repository.
 
 |Date|Headline|
 |---|---|
+|2026-07-17|[Gatekeeper — Automatic SCC Assignment](cluster-configuration/gatekeeper-opa/automatic-scc-assignment/)|
 |2026-07-10|[Updated SCC anyuid page with selection process and modern examples](deploy/scc-anyuid.md)|
 |2026-07-03|[Updated KubeVirt networking: OVN-Bridge, Linux-Bridge, ClusterUserDefinedNetwork](kubevirt/networking/)|
 |2026-05-29|[Updated disconnected installation section](cluster-installation/disconnected/)|

--- a/content/cluster-configuration/gatekeeper-opa/automatic-scc-assignment/assign-metadata.yaml
+++ b/content/cluster-configuration/gatekeeper-opa/automatic-scc-assignment/assign-metadata.yaml
@@ -1,0 +1,20 @@
+apiVersion: mutations.gatekeeper.sh/v1
+kind: AssignMetadata
+metadata:
+  name: assign-required-scc-annotation
+spec:
+  match:
+    scope: Namespaced
+    kinds:
+      - apiGroups:
+          - ""
+        kinds:
+          - Pod
+    labelSelector: {}
+    namespaceSelector:
+      matchLabels:
+        examples.openshift.pub/scc-assignment: "true"
+  location: 'metadata.annotations."openshift.io/required-scc"'
+  parameters:
+    assign:
+      value: anyuid-without-prio

--- a/content/cluster-configuration/gatekeeper-opa/automatic-scc-assignment/assign-namespace-label.yaml
+++ b/content/cluster-configuration/gatekeeper-opa/automatic-scc-assignment/assign-namespace-label.yaml
@@ -1,0 +1,27 @@
+apiVersion: mutations.gatekeeper.sh/v1
+kind: AssignMetadata
+metadata:
+  name: assign-scc-assignment-label
+spec:
+  match:
+    scope: Cluster
+    kinds:
+      - apiGroups:
+          - ""
+        kinds:
+          - Namespace
+    namespaceSelector: {}
+    labelSelector:
+      matchExpressions:
+        - key: examples.openshift.pub/scc-assignment
+          operator: DoesNotExist
+    namespacesInScope:
+      include:
+        - "*"
+      exclude:
+        - kube-*
+        - openshift-*
+  location: 'metadata.labels."examples.openshift.pub/scc-assignment"'
+  parameters:
+    assign:
+      value: "true"

--- a/content/cluster-configuration/gatekeeper-opa/automatic-scc-assignment/clusterrole-use-anyuid-without-prio.yaml
+++ b/content/cluster-configuration/gatekeeper-opa/automatic-scc-assignment/clusterrole-use-anyuid-without-prio.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: use-anyuid-without-prio
+rules:
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - anyuid-without-prio
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use

--- a/content/cluster-configuration/gatekeeper-opa/automatic-scc-assignment/clusterrolebinding-use-anyuid-without-prio.yaml
+++ b/content/cluster-configuration/gatekeeper-opa/automatic-scc-assignment/clusterrolebinding-use-anyuid-without-prio.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: use-anyuid-without-prio
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: use-anyuid-without-prio
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:serviceaccounts

--- a/content/cluster-configuration/gatekeeper-opa/automatic-scc-assignment/index.md
+++ b/content/cluster-configuration/gatekeeper-opa/automatic-scc-assignment/index.md
@@ -39,7 +39,7 @@ flowchart LR
         D -- No --> E[Gatekeeper adds\nlabel=true]
         D -- Yes --> F([Label kept as-is])
     end
-    
+
     subgraph pod ["Pod Mutation"]
         E --> G([Pod creation])
         F --> G

--- a/content/cluster-configuration/gatekeeper-opa/automatic-scc-assignment/index.md
+++ b/content/cluster-configuration/gatekeeper-opa/automatic-scc-assignment/index.md
@@ -6,14 +6,15 @@ tags: ['gatekeeper','opa','scc','security','v4.21']
 ---
 # Gatekeeper — Automatic SCC Assignment
 
+!!! warning
+
+    This is not recommended — you bypass one of OpenShift's core security features.
+    Only use this in controlled environments where you fully understand the implications.
+
 This setup uses OPA Gatekeeper mutations to automatically assign a specific SCC
 to every workload namespace cluster-wide. Gatekeeper labels each namespace and
 then injects the `openshift.io/required-scc` annotation onto pods, ensuring
 OpenShift uses the designated SCC instead of its default selection logic.
-
-!!! info
-
-    `AssignMetadata` only sets a value when the field is **not already present** — pods with an existing `openshift.io/required-scc` annotation are not touched.
 
 Official documentation:
 
@@ -31,17 +32,23 @@ Tested with:
 
 ```mermaid
 flowchart LR
-    A([Namespace created]) --> B{Name starts with\nopenshift-* or kube-*?}
-    B -- Yes --> C([Skipped — no mutation])
-    B -- No --> D{Has label\nscc-assignment?}
-    D -- No --> E[Gatekeeper adds\nlabel=true]
-    D -- Yes --> F([Label kept as-is])
-    E --> G([Pod created in namespace])
-    F --> G
-    G --> H{Label\nscc-assignment=true?}
-    H -- No --> I([Pod admitted — default SCC applies])
-    H -- Yes --> J[Gatekeeper injects annotation\nopenshift.io/required-scc:\nanyuid-without-prio]
-    J --> K([OpenShift uses anyuid-without-prio SCC])
+    subgraph ns ["Namespace Mutation"]
+        A([Namespace creation]) --> B{Name starts with\nopenshift-* or kube-*?}
+        B -- Yes --> C([Skipped — no mutation])
+        B -- No --> D{Has label\nscc-assignment?}
+        D -- No --> E[Gatekeeper adds\nlabel=true]
+        D -- Yes --> F([Label kept as-is])
+    end
+    
+    subgraph pod ["Pod Mutation"]
+        E --> G([Pod creation])
+        F --> G
+        G --> H{Has annotation\nopenshift.io/required-scc}
+        H -- Yes --> X(Done)
+        H -- No --> K{Label at Namespace\nscc-assignment==true?}
+        K -- No --> I([Pod admitted — default SCC applies])
+        K -- Yes --> J[Inject annotation\nopenshift.io/required-scc]
+    end
 ```
 
 ## Prerequisites
@@ -78,13 +85,13 @@ That's the reason why I created a copy of anyuid without a prio:
 
 Now it's time to allow all services accounts (group `system:serviceaccounts`) to use our own SCC.
 
-=== "clusterrole-use-anyuid-without-prio.yaml"
+=== "ClusterRole"
 
     ```yaml
     --8<-- "content/cluster-configuration/gatekeeper-opa/automatic-scc-assignment/clusterrole-use-anyuid-without-prio.yaml"
     ```
 
-=== "clusterrolebinding-use-anyuid-without-prio.yaml"
+=== "ClusterRoleBinding"
 
     ```yaml
     --8<-- "content/cluster-configuration/gatekeeper-opa/automatic-scc-assignment/clusterrolebinding-use-anyuid-without-prio.yaml"
@@ -103,7 +110,7 @@ Let's apply our two mutations.
 
 #### 3.1. Ensure the namespace labeling
 
-=== "assign-namespace-label.yaml"
+=== "AssignMetadata to Namespace"
 
     ```yaml
     --8<-- "content/cluster-configuration/gatekeeper-opa/automatic-scc-assignment/assign-namespace-label.yaml"
@@ -119,7 +126,11 @@ Let's apply our two mutations.
 
 Add the annotation `openshift.io/required-scc` to all pods in namespaces with a specific label.
 
-=== "assign-metadata.yaml"
+!!! info
+
+    `AssignMetadata` only sets a value when the field is **not already present** — pods with an existing `openshift.io/required-scc` annotation are not touched.
+
+=== "AssignMetadata to Pod"
 
     ```yaml
     --8<-- "content/cluster-configuration/gatekeeper-opa/automatic-scc-assignment/assign-metadata.yaml"
@@ -177,15 +188,3 @@ test-app    simple-http-server-7fbb8879-7mvzb   restricted-v2   <none>
 
 The Gatekeeper mutation only fires when the label is absent, so an explicit
 `"false"` value is preserved and the SCC annotation is not injected.
-
-## Security Considerations
-
-- The `anyuid-without-prio` SCC has **no priority**, so it is never automatically
-  selected by OpenShift's SCC admission. It is only used when explicitly
-  requested via the `openshift.io/required-scc` annotation.
-- The SCC still drops the `MKNOD` capability and does not allow host-level
-  access (hostNetwork, hostPID, hostIPC, hostPath volumes, or privileged
-  containers).
-- The ClusterRoleBinding grants usage to **all** service accounts
-  (`system:serviceaccounts`). Restrict the binding to specific namespaces or
-  service accounts if needed.

--- a/content/cluster-configuration/gatekeeper-opa/automatic-scc-assignment/index.md
+++ b/content/cluster-configuration/gatekeeper-opa/automatic-scc-assignment/index.md
@@ -1,0 +1,191 @@
+---
+title: Gatekeeper — Automatic SCC Assignment
+linktitle: Gatekeeper — SCC Assignment
+description: Use OPA Gatekeeper mutations to automatically assign a specific SCC to all workloads cluster-wide, bypassing OpenShift's default SCC selection.
+tags: ['gatekeeper','opa','scc','security','v4.21']
+---
+# Gatekeeper — Automatic SCC Assignment
+
+This setup uses OPA Gatekeeper mutations to automatically assign a specific SCC
+to every workload namespace cluster-wide. Gatekeeper labels each namespace and
+then injects the `openshift.io/required-scc` annotation onto pods, ensuring
+OpenShift uses the designated SCC instead of its default selection logic.
+
+!!! info
+
+    `AssignMetadata` only sets a value when the field is **not already present** — pods with an existing `openshift.io/required-scc` annotation are not touched.
+
+Official documentation:
+
+- [OPA Gatekeeper](https://open-policy-agent.github.io/gatekeeper/website/)
+- [Managing SCCs in OpenShift](https://docs.openshift.com/container-platform/latest/authentication/managing-security-context-constraints.html)
+
+Tested with:
+
+|Component|Version|
+|---|---|
+|OpenShift|v4.21.22|
+|OPA Gatekeeper|v3.21.0|
+
+## How It Works
+
+```mermaid
+flowchart LR
+    A([Namespace created]) --> B{Name starts with\nopenshift-* or kube-*?}
+    B -- Yes --> C([Skipped — no mutation])
+    B -- No --> D{Has label\nscc-assignment?}
+    D -- No --> E[Gatekeeper adds\nlabel=true]
+    D -- Yes --> F([Label kept as-is])
+    E --> G([Pod created in namespace])
+    F --> G
+    G --> H{Label\nscc-assignment=true?}
+    H -- No --> I([Pod admitted — default SCC applies])
+    H -- Yes --> J[Gatekeeper injects annotation\nopenshift.io/required-scc:\nanyuid-without-prio]
+    J --> K([OpenShift uses anyuid-without-prio SCC])
+```
+
+## Prerequisites
+
+- OpenShift 4.x cluster
+- OPA Gatekeeper installed with mutation enabled
+
+## Installation
+
+### 1. Install the Gatekeeper Operator
+
+Install the **Gatekeeper Operator** from OperatorHub (search for "Gatekeeper") and create
+a `Gatekeeper` CR with `mutatingWebhook: Enabled`. See the
+[Chapter 5. Gatekeeper operator overview](https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.17/html/governance/gk-operator-overview)
+for details, or the [upstream operator README](https://github.com/open-policy-agent/gatekeeper-operator#readme).
+
+### 2. Create the SCC and RBAC
+
+In this example, all workloads should run with any UID. The built-in `anyuid` SCC has a higher priority and would always win, meaning it would also be applied to workloads not intended to run as anyuid.
+
+That's the reason why I created a copy of anyuid without a prio:
+
+=== "scc-anyuid-without-prio.yaml"
+
+    ```yaml
+    --8<-- "content/cluster-configuration/gatekeeper-opa/automatic-scc-assignment/scc-anyuid-without-prio.yaml"
+    ```
+
+=== "oc apply"
+
+    ```shell
+    oc apply -f {{ page.canonical_url }}scc-anyuid-without-prio.yaml
+    ```
+
+Now it's time to allow all services accounts (group `system:serviceaccounts`) to use our own SCC.
+
+=== "clusterrole-use-anyuid-without-prio.yaml"
+
+    ```yaml
+    --8<-- "content/cluster-configuration/gatekeeper-opa/automatic-scc-assignment/clusterrole-use-anyuid-without-prio.yaml"
+    ```
+
+=== "clusterrolebinding-use-anyuid-without-prio.yaml"
+
+    ```yaml
+    --8<-- "content/cluster-configuration/gatekeeper-opa/automatic-scc-assignment/clusterrolebinding-use-anyuid-without-prio.yaml"
+    ```
+
+=== "oc apply"
+
+    ```shell
+    oc apply -f {{ page.canonical_url }}clusterrole-use-anyuid-without-prio.yaml
+    oc apply -f {{ page.canonical_url }}clusterrolebinding-use-anyuid-without-prio.yaml
+    ```
+
+### 3. Deploy the Gatekeeper mutations
+
+Let's apply our two mutations.
+
+#### 3.1. Ensure the namespace labeling
+
+=== "assign-namespace-label.yaml"
+
+    ```yaml
+    --8<-- "content/cluster-configuration/gatekeeper-opa/automatic-scc-assignment/assign-namespace-label.yaml"
+    ```
+
+=== "oc apply"
+
+    ```shell
+    oc apply -f {{ page.canonical_url }}assign-namespace-label.yaml
+    ```
+
+#### 3.2. Add `openshift.io/required-scc` to all Pods
+
+Add the annotation `openshift.io/required-scc` to all pods in namespaces with a specific label.
+
+=== "assign-metadata.yaml"
+
+    ```yaml
+    --8<-- "content/cluster-configuration/gatekeeper-opa/automatic-scc-assignment/assign-metadata.yaml"
+    ```
+
+=== "oc apply"
+
+    ```shell
+    oc apply -f {{ page.canonical_url }}assign-metadata.yaml
+    ```
+
+### 4. Verify
+
+Create a namespace and deploy an application:
+
+```shell
+oc create namespace test-app
+oc project test-app
+oc apply -k git@github.com:openshift-examples/kustomize/components/simple-http-server
+```
+
+```shell
+% oc get pods -o custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name,SCC:.metadata.annotations."openshift\.io/scc",REQ-SCC:.metadata.annotations."openshift\.io/required-scc"
+NAMESPACE   NAME                                SCC                   REQ-SCC
+test-app    simple-http-server-7fbb8879-sn9tx   anyuid-without-prio   anyuid-without-prio
+```
+
+🎉 SCC `anyuid-without-prio` is in use and required.
+
+## Opting Out
+
+To exclude a namespace from automatic SCC assignment, explicitly set the label
+to `"false"`:
+
+```shell
+oc label --overwrite namespace/test-app examples.openshift.pub/scc-assignment=false
+```
+
+Force to restart pods:
+
+```shell
+oc delete pods --all
+```
+
+Let's check the pods again:
+
+```shell
+% oc get pods -o custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name,SCC:.metadata.annotations."openshift\.io/scc",REQ-SCC:.metadata.annotations."openshift\.io/required-scc"
+
+NAMESPACE   NAME                                SCC             REQ-SCC
+test-app    simple-http-server-7fbb8879-7mvzb   restricted-v2   <none>
+```
+
+🎉 default SCC `restricted-v2` is in use and no specific SCC is required.
+
+The Gatekeeper mutation only fires when the label is absent, so an explicit
+`"false"` value is preserved and the SCC annotation is not injected.
+
+## Security Considerations
+
+- The `anyuid-without-prio` SCC has **no priority**, so it is never automatically
+  selected by OpenShift's SCC admission. It is only used when explicitly
+  requested via the `openshift.io/required-scc` annotation.
+- The SCC still drops the `MKNOD` capability and does not allow host-level
+  access (hostNetwork, hostPID, hostIPC, hostPath volumes, or privileged
+  containers).
+- The ClusterRoleBinding grants usage to **all** service accounts
+  (`system:serviceaccounts`). Restrict the binding to specific namespaces or
+  service accounts if needed.

--- a/content/cluster-configuration/gatekeeper-opa/automatic-scc-assignment/scc-anyuid-without-prio.yaml
+++ b/content/cluster-configuration/gatekeeper-opa/automatic-scc-assignment/scc-anyuid-without-prio.yaml
@@ -1,0 +1,34 @@
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: anyuid-without-prio
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities: null
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups: []
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - MKNOD
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users: []
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - persistentVolumeClaim
+  - projected
+  - secret

--- a/content/cluster-configuration/gatekeeper-opa/index.md
+++ b/content/cluster-configuration/gatekeeper-opa/index.md
@@ -1,0 +1,22 @@
+---
+title: Gatekeeper / OPA
+linktitle: Gatekeeper / OPA
+description: OPA Gatekeeper examples for OpenShift cluster configuration.
+tags: ['gatekeeper','opa','security']
+---
+# Gatekeeper / OPA
+
+{% set current_page_title = page.title %}
+{% for n in navigation if n.title == current_page_title %}
+{% for c in n.children if c.title != current_page_title %}
+{% if c.abs_url is string %}
+
+- [{{ c.title }}]({{c.canonical_url}})
+
+{% else %}
+
+- **[{{ c.title }}]({{ c.children[0].canonical_url }})**
+
+{% endif %}
+{% endfor %}
+{% endfor %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,7 @@ extra:
 extra_javascript:
   - https://viewer.diagrams.net/js/viewer-static.min.js
   - javascripts/drawio-reload.js
+  - https://unpkg.com/mermaid@11/dist/mermaid.min.js
 
 # Extensions
 markdown_extensions:
@@ -73,7 +74,11 @@ markdown_extensions:
       line_spans: __span
       pygments_lang_class: true
   - pymdownx.inlinehilite
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.tabbed:
       alternate_style: true
   - toc:
@@ -189,6 +194,9 @@ nav:
           - Debugging: cluster-configuration/MachineSets/debugging.md
           - "VMware UPI": cluster-configuration/MachineSets/VMware-UPI/index.md
       - Cluster autoscaler: cluster-configuration/cluster-autoscaling.md
+      - Gatekeeper / OPA:
+          - cluster-configuration/gatekeeper-opa/index.md
+          - Automatic SCC Assignment: cluster-configuration/gatekeeper-opa/automatic-scc-assignment/index.md
 
   - Cluster lifecycle:
       - cluster-lifecycle/index.md


### PR DESCRIPTION
- New page under cluster-configuration/gatekeeper-opa/automatic-scc-assignment/ documenting how to use OPA Gatekeeper mutations to automatically assign a specific SCC (anyuid-without-prio) to all workloads cluster-wide
- mkdocs.yml nav updated to a Gatekeeper / OPA section with child entry
- content/README.md last-updates row updated